### PR TITLE
Addition of gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Cache folder
+/_cache/


### PR DESCRIPTION
This PR adds a .gitignore file to our Cashew fork and includes the /_cache folder. 

Delivers:
[Sexton - Ensure IG lib '_cache' folder doesn't get tracked by Git](https://app.asana.com/0/888470197607876/1104467585781396)